### PR TITLE
Remove explicit Python 2 requirement for RAM-generator scripts

### DIFF
--- a/py/lab_hammer_hooks.py
+++ b/py/lab_hammer_hooks.py
@@ -46,10 +46,10 @@ def fakeram_gen_macro_swaps(x: hammer_vlsi.HammerTool) -> bool:
     os.system(f'cat {bsg_root}/hard/fakeram/bsg_mem_1rw_sync_macros.vh                  > {hard_swap_v_name}')
     os.system(f'cat {bsg_root}/hard/fakeram/bsg_mem_1rw_sync_mask_write_bit_macros.vh  >> {hard_swap_v_name}')
     os.system(f'cat {bsg_root}/hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.vh >> {hard_swap_v_name}')
-    # Generate and concatinate hard swap files for all 3 types of rams. Must use Python 2! :(
-    os.system(f'python2 {swap_gen_script_path} {swap_gen_cfg} 1rw 0                    >> {hard_swap_v_name}')
-    os.system(f'python2 {swap_gen_script_path} {swap_gen_cfg} 1rw 1                    >> {hard_swap_v_name}')
-    os.system(f'python2 {swap_gen_script_path} {swap_gen_cfg} 1rw 8                    >> {hard_swap_v_name}')
+    # Generate and concatinate hard swap files for all 3 types of rams
+    os.system(f'{swap_gen_script_path} {swap_gen_cfg} 1rw 0                            >> {hard_swap_v_name}')
+    os.system(f'{swap_gen_script_path} {swap_gen_cfg} 1rw 1                            >> {hard_swap_v_name}')
+    os.system(f'{swap_gen_script_path} {swap_gen_cfg} 1rw 8                            >> {hard_swap_v_name}')
     # Create library for hard swap verilog file. Use it for both synthesis and simulation
     x.output_libraries.append(ExtraLibrary(
         prefix=None, library=Library(


### PR DESCRIPTION
Instead of explicitly calling `python2`, these scripts can be run directly.
They're already executable and have shebangs, so they can specify their own Python versions if needed.

Also, there's an [accompanying PR on basejump_stl](https://github.com/bespoke-silicon-group/basejump_stl/pull/717) to remove the Python 2 dependency entirely, so this pairs very well with that.
